### PR TITLE
fix check to accept Location type in move method

### DIFF
--- a/pydraw/location.py
+++ b/pydraw/location.py
@@ -46,7 +46,7 @@ class Location:
         diff = (0, 0);
 
         # Basically we don't have an empty tuple at the start.
-        if len(args) > 0 and (type(args[0]) is float or type(args[0]) is int or type(args[0]) is diff or
+        if len(args) > 0 and (type(args[0]) is float or type(args[0]) is int or type(args[0]) is Location or
                               type(args[0]) is tuple and not len(args[0]) == 0):
             if len(args) == 1 and type(args[0]) is tuple or type(args[0]) is Location:
                 diff = (args[0][0], args[0][1]);

--- a/pydraw/objects.py
+++ b/pydraw/objects.py
@@ -57,7 +57,7 @@ class Pen:
         diff = (0, 0);
 
         # Basically we don't have an empty tuple at the start.
-        if len(args) > 0 and (type(args[0]) is float or type(args[0]) is int or type(args[0]) is diff or
+        if len(args) > 0 and (type(args[0]) is float or type(args[0]) is int or type(args[0]) is Location or
                               type(args[0]) is tuple and not len(args[0]) == 0):
             if len(args) == 1 and type(args[0]) is tuple or type(args[0]) is Location:
                 diff = (args[0][0], args[0][1]);


### PR DESCRIPTION
What?: type(args[0]) is diff did not make sense to me, as I investigated, why Oval.move(Location) throws an error, so I replaced it with type(args[0]) is Location and it worked for me and also made sense to me when looking at the following lines (if len(args) == 1 and type(args[0]) is tuple or type(args[0]) is Location:)

Why?: The reason I tried to pass a Location to Oval.move is, because I used Location as a velocity-vector. In the future, a dedicated vector class would be better though, as that would make it possible to add dedicated vector operations to that class.