### PR TITLE
Fix docstring rendering: blank line before reST field lists

### DIFF
--- a/pydraw/color.py
+++ b/pydraw/color.py
@@ -66,6 +66,7 @@ class Color:
     def __value__(self):
         """
         Retrieves the value to be interpreted internally by Turtle
+
         :return:
         """
         if self._mode == 0:
@@ -78,6 +79,7 @@ class Color:
     def red(self):
         """
         Get the red property.
+
         :return: r
         """
         return self._r
@@ -85,6 +87,7 @@ class Color:
     def green(self):
         """
         Get the green property
+
         :return: g
         """
         return self._g
@@ -92,6 +95,7 @@ class Color:
     def blue(self):
         """
         Get the blue property
+
         :return: b
         """
         return self._b
@@ -99,6 +103,7 @@ class Color:
     def rgb(self):
         """
         Get the RGB tuple
+
         :return: tuple (R, G, B)
         """
         return self.red(), self.green(), self.blue()
@@ -106,6 +111,7 @@ class Color:
     def name(self):
         """
         Get the name of the color (only if defined)
+
         :return: color or None
         """
 
@@ -114,6 +120,7 @@ class Color:
     def hex(self):
         """
         Get the hex of the color (only if defined)
+
         :return: hex_value or None
         """
         return self._hex_value
@@ -121,6 +128,7 @@ class Color:
     def clone(self):
         """
         Clone this color!
+
         :return: a clone.
         """
 
@@ -146,6 +154,7 @@ class Color:
     def _rgb(color) -> tuple:
         """
         Convert a color to an rgb tuple.
+
         :param color: the color to convert
         :return: a tuple representing RGB
         """
@@ -179,6 +188,7 @@ class Color:
     def all():
         """
         Get all color values that have a string-name.
+
         :return: a tuple (immutable list) of all Colors.
         """
 
@@ -188,6 +198,7 @@ class Color:
     def random():
         """
         Retrieve a random Color.
+
         :return: returns
         """
 

--- a/pydraw/compound.py
+++ b/pydraw/compound.py
@@ -15,6 +15,7 @@ class CompoundObject(Object):
     def __init__(self, *args, **kwargs):
         """
         Pass in the shapes/objects to be used to create the CompoundObject
+
         :param args: the shapes/objects to use
         :param kwargs: shapes/objects to use that along with identifiers
         """
@@ -61,6 +62,7 @@ class CompoundObject(Object):
     def x(self, x: float = None) -> float:
         """
         Get the x coordinate of the compound system.
+
         :param x: a new x, if provided
         :return: a float
         """
@@ -74,6 +76,7 @@ class CompoundObject(Object):
     def y(self, y: float = None) -> float:
         """
         Get the y coordinate of the compound system.
+
         :param y: a new y, if provided
         :return: a float
         """
@@ -87,6 +90,7 @@ class CompoundObject(Object):
     def move(self, *args, **kwargs) -> None:
         """
         Move the compound shape by a certain distance (dx, dy)
+
         :return: None
         """
 
@@ -98,6 +102,7 @@ class CompoundObject(Object):
     def moveto(self, *args, **kwargs) -> None:
         """
         Move the compound shape to a new location (x, y)
+
         :return: None
         """
 
@@ -112,6 +117,7 @@ class CompoundObject(Object):
     def width(self, width: float = None) -> float:
         """
         Get the width of the compound object
+
         :param width: a new width, if provided
         :return: a float
         """
@@ -124,6 +130,7 @@ class CompoundObject(Object):
     def height(self, height: float = None) -> float:
         """
         Get the height of the compound object
+
         :param height: a new height, if provided
         :return: a float
         """
@@ -136,6 +143,7 @@ class CompoundObject(Object):
     def rotate(self, angle_diff: float, pivot: Location = None) -> None:
         """
         Rotate the angle of the compound object by a difference, around a pivot point, in degrees
+
         :param angle_diff: the angle difference to rotate by
         :param pivot: the pivot point to rotate around
         :return: None
@@ -169,6 +177,7 @@ class CompoundObject(Object):
     def rotation(self, angle: float = None) -> float:
         """
         Get the rotation of the compound object
+
         :param angle: a new rotation, if provided
         :return: a float
         """
@@ -181,6 +190,7 @@ class CompoundObject(Object):
     def center(self, centroid: bool = True) -> Location:
         """
         Calculate the center point of the CompoundObject
+
         :centroid: whether to use the centroid or the center of the bounding box
         :return: Location of the center
         """
@@ -204,6 +214,7 @@ class CompoundObject(Object):
     def contains(self, *args) -> bool:
         """
         Check if the CompoundObject contains a certain Location
+
         :param args: the Location to check
         :return: True if the CompoundObject contains the Location, False otherwise
         """
@@ -241,6 +252,7 @@ class CompoundObject(Object):
     def overlaps(self, other: 'Renderable') -> bool:
         """
         Returns if this compound object is overlapping with the passed object.
+
         :param other: another Renderable instance.
         :return: true if they are overlapping, false if not.
         """
@@ -261,6 +273,7 @@ class CompoundObject(Object):
         """
         Brings the compound object to the front of the Screen
         (Imagine moving forward on the Z axis)
+
         :return: None
         """
 
@@ -271,6 +284,7 @@ class CompoundObject(Object):
         """
         Brings the compound object to the back of the Screen
         (Imagine moving backward on the Z axis)
+
         :return: None
         """
 
@@ -280,6 +294,7 @@ class CompoundObject(Object):
     def add(self, obj: Object, name=None) -> None:
         """
         Add another Object to the CompoundObject
+
         :param obj: the Object to add
         :return: None
         """
@@ -308,6 +323,7 @@ class CompoundObject(Object):
     def remove(self, obj: Object = None, name=None) -> Object:
         """
         Remove an object from the Compound Object
+
         :param obj: the object to remove
         :param name: the name the object is registered under
         :return: the Object that got removed (or None)
@@ -325,6 +341,7 @@ class CompoundObject(Object):
     def object(self, name) -> Object:
         """
         Retrieve a specific object
+
         :param name: the name of the object (can be a str, or another type of object)
         :return: Object
         """
@@ -334,6 +351,7 @@ class CompoundObject(Object):
     def objects(self) -> tuple:
         """
         Retrieve a tuple of all objects in the compound shape.
+
         :return: a tuple
         """
 

--- a/pydraw/location.py
+++ b/pydraw/location.py
@@ -38,6 +38,7 @@ class Location:
         Moves the location by a specified difference.
 
         Can take two numbers (dx, dy), a tuple, or a Location
+
         :param dx: the dx to move by
         :param dy: the dy to move by
         :return: the location (after change)
@@ -79,6 +80,7 @@ class Location:
         Moves the location to a new location!
 
         Can take two coordinates (x, y), a tuple, or a Location
+
         :param x: the x to move to
         :param y: the y to move to
         :return: the location (after change)
@@ -130,6 +132,7 @@ class Location:
     def distance(self, location) -> float:
         """
         Returns the distance between this location and another
+
         :param location: the Location to get the distance to
         :return: a float
         """
@@ -139,6 +142,7 @@ class Location:
     def clone(self):
         """
         Clone the Location
+
         :return: a new Location with the same x and y as this one.
         """
 

--- a/pydraw/objects.py
+++ b/pydraw/objects.py
@@ -52,6 +52,7 @@ class Pen:
         Requires coordinates to be len > 0.
 
         Can take two numbers (dx, dy), a tuple, or a Location
+
         :param dx: the dx to move by
         :param dy: the dy to move by
         :return: the location (after change)
@@ -99,6 +100,7 @@ class Pen:
         Adds a new coordinate to the pen line.
 
         Can take two coordinates (x, y), a tuple, or a Location
+
         :param x: the x to move to
         :param y: the y to move to
         :return: the location (after change)
@@ -307,6 +309,7 @@ class Object:
     def move(self, *args, **kwargs) -> None:
         """
         Can take either a tuple, Location, or two numbers (dx, dy)
+
         :return: None
         """
 
@@ -316,6 +319,7 @@ class Object:
     def moveto(self, *args, **kwargs) -> None:
         """
         Move to a new location takes a Location, tuple, or two numbers (x, y)
+
         :return: None
         """
 
@@ -333,6 +337,7 @@ class Object:
         """
         Brings the object to the front of the Screen
         (Imagine moving forward on the Z axis)
+
         :return: None
         """
 
@@ -343,6 +348,7 @@ class Object:
         """
         Brings the object to the back of the Screen
         (Imagine moving backward on the Z axis)
+
         :return: None
         """
 
@@ -1190,6 +1196,7 @@ class Renderable(Object):
     def move(self, *args, **kwargs) -> None:
         """
         Can take either a tuple, Location, or two numbers (dx, dy)
+
         :return: None
         """
 
@@ -1203,6 +1210,7 @@ class Renderable(Object):
     def moveto(self, *args, **kwargs) -> None:
         """
         Move to a new location takes a Location, tuple, or two numbers (x, y)
+
         :return: None
         """
 
@@ -1216,6 +1224,7 @@ class Renderable(Object):
     def width(self, width: float = None) -> float:
         """
         Get or set the width of the object.
+
         :param width: the width to set to in pixels, if any
         :return: the width of the object
         """
@@ -1242,6 +1251,7 @@ class Renderable(Object):
     def height(self, height: float = None) -> float:
         """
         Get or set the height of the object
+
         :param height: the height to set to in pixels, if any
         :return: the height of the object
         """
@@ -1269,6 +1279,7 @@ class Renderable(Object):
     def center(self, *args, **kwargs) -> Location:
         """
         Returns the location of the center
+
         :param move_to: if defined, Move the center to a new Location (Easily center objects!)
         :param x: if defined, move the center x-coordinate to the specified value
         :param y: if defined, move the center y-coordinate to the specified value
@@ -1355,6 +1366,7 @@ class Renderable(Object):
     def rotation(self, angle: float = None) -> float:
         """
         Get or set the rotation of the object.
+
         :param angle: the angle to set the rotation to in degrees, if any
         :return: the angle of the object's rotation in degrees
         """
@@ -1370,6 +1382,7 @@ class Renderable(Object):
     def rotate(self, angle_diff: float = 0) -> None:
         """
         Rotate the angle of the object by a difference, in degrees
+
         :param angle_diff: the angle difference to rotate by
         :return: None
         """
@@ -1380,6 +1393,7 @@ class Renderable(Object):
     def angleto(self, obj) -> float:
         """
         Retrieve the angle between this object and another (based on 0 degrees at 12 o'clock)
+
         :param obj: the Object/Location to get the angle to.
         :return: the angle in degrees as a float
         """
@@ -1400,6 +1414,7 @@ class Renderable(Object):
     def lookat(self, obj) -> None:
         """
         Look at another object (Objects or Locations)
+
         :param obj: the Object/Location to look at.
         :return: None
         """
@@ -1410,6 +1425,7 @@ class Renderable(Object):
     def forward(self, distance: float) -> None:
         """
         Move the Renderable forward by distance at its current heading (rotation/angle)
+
         :param distance: the distance to move forward (hypotenuse)
         :return: None
         """
@@ -1422,6 +1438,7 @@ class Renderable(Object):
     def backward(self, distance: float) -> None:
         """
         Move the Renderable backward by distance at its current heading (rotation/angle)
+
         :param distance: the distance to move backward (hypotenuse)
         :return: None
         """
@@ -1431,6 +1448,7 @@ class Renderable(Object):
     def color(self, color: Color = None) -> Color:
         """
         Get or set the color of the object
+
         :param color: the color to set to, if any
         :return: the color of the object
         """
@@ -1449,6 +1467,7 @@ class Renderable(Object):
     def border(self, color: Color = None, width: float = None, fill: bool = None) -> Color:
         """
         Add or get the border of the object
+
         :param color: the color to set the border too, set to Color.NONE to remove border
         :param width: the width of the border
         :param fill: whether to fill the polygon.
@@ -1482,6 +1501,7 @@ class Renderable(Object):
     def border_width(self, width: float = None) -> float:
         """
         Gets or sets the border width
+
         :param width: the border width to set to
         :return: the border width
         """
@@ -1497,6 +1517,7 @@ class Renderable(Object):
     def fill(self, fill: bool = None) -> bool:
         """
         Returns or sets the current fill boolean
+
         :param fill: a new fill value, whether to fill the polygon
         :return: the fill value
         """
@@ -1514,6 +1535,7 @@ class Renderable(Object):
     def distance(self, obj) -> float:
         """
         Returns the distance between two objs or locations in pixels (center to center)
+
         :param obj: the Renderable/location to check distance between
         :return: the distance between this obj and the passed Renderable/Location.
         """
@@ -1529,6 +1551,7 @@ class Renderable(Object):
     def visible(self, visible: bool = None) -> bool:
         """
         Get or set the visibility of the renderable.
+
         :param visible: the new visibility value, if any
         :return: the visibility value
         """
@@ -1549,6 +1572,7 @@ class Renderable(Object):
         Transforms represent the width, height, and rotation of Renderables.
 
         You can retrieve a Transform from a Renderable with this method and set the transform the same way.
+
         :param transform: the transform to set to, if any.
         :return: the transform
         """
@@ -1568,6 +1592,7 @@ class Renderable(Object):
     def clone(self):
         """
         Clone this renderable!
+
         :return: a Renderable
         """
 
@@ -1579,6 +1604,7 @@ class Renderable(Object):
         """
         Returns the list of vertices for the Renderable.
         (The vertices will be returned clockwise, starting from the top-leftmost point)
+
         :return: a list of Locations representing the vertices
         """
 
@@ -1588,6 +1614,7 @@ class Renderable(Object):
     def bounds(self) -> (Location, float, float):
         """
         Get the location and dimensions of a bounding box that contains the entire shape
+
         :return: a tuple containing the Location, width, and height.
         """
 
@@ -1603,6 +1630,7 @@ class Renderable(Object):
     def contains(self, *args) -> bool:
         """
         Returns whether a Location is contained within the object.
+
         :param args: You may pass in either two numbers, a Location, or a tuple containing and x and y point.
         :return: a boolean value representing whether the point is within the vertices of the object.
         """
@@ -1676,6 +1704,7 @@ class Renderable(Object):
     def overlaps(self, other: 'Renderable') -> bool:
         """
         Returns if this object is overlapping with the passed object.
+
         :param other: another Renderable instance.
         :return: true if they are overlapping, false if not.
         """
@@ -1778,6 +1807,7 @@ class Renderable(Object):
             """
             Internal method that will determine the orientation of three points. They can be a clockwise triangle,
             counterclockwise triangle, or a co-linear line segment.
+
             :param point1: the first point of the main line segment
             :param point2: the second point of the main line segment
             :param point3: the third point to check from another line segment
@@ -2136,6 +2166,7 @@ class RoundedRectangle(CustomRenderable):
     def radius(self, radius: float = None) -> float:
         """
         Set the border radius of the rounded shape.
+
         :param radius: the radius to set to (not pixel accurate)
         :return: the radius
         """
@@ -2317,6 +2348,7 @@ class CustomPolygon(CustomRenderable):
     def move(self, *args, **kwargs):
         """
         Can take either a tuple, Location, or two numbers (dx, dy)
+
         :return: None
         """
 
@@ -2334,6 +2366,7 @@ class CustomPolygon(CustomRenderable):
     def moveto(self, *args, **kwargs):
         """
         Move to a new location takes a Location, tuple, or two numbers (x, y)
+
         :return: None
         """
 
@@ -2345,6 +2378,7 @@ class CustomPolygon(CustomRenderable):
     def width(self, width: float = None) -> float:
         """
         Get the width of the CustomPolygon
+
         :param width: Unsupported.
         :return: the width of the object
         """
@@ -2363,6 +2397,7 @@ class CustomPolygon(CustomRenderable):
     def height(self, height: float = None) -> float:
         """
         Get the height of the Polygon
+
         :param height: Unsupported.
         :return: the height of the object
         """
@@ -2398,6 +2433,7 @@ class CustomPolygon(CustomRenderable):
     def center(self, *args, **kwargs) -> Location:
         """
         Returns the location of the center
+
         :param move_to: if defined, Move the center to a new Location (Easily center objects!)
         :param x: if defined, move the center x-coordinate to the specified value
         :param y: if defined, move the center y-coordinate to the specified value
@@ -2480,6 +2516,7 @@ class CustomPolygon(CustomRenderable):
     def clone(self):
         """
         Clone this CustomPolygon!
+
         :return: a CustomPolygon
         """
         return CustomPolygon(self._screen, self._vertices, self._color, self._border, self._fill, self._angle,
@@ -2848,6 +2885,7 @@ class Oval(Renderable):
     def width(self, width: float = None) -> float:
         """
         Get or set the width of the object.
+
         :param width: the width to set to in pixels, if any
         :return: the width of the object
         """
@@ -2862,6 +2900,7 @@ class Oval(Renderable):
     def height(self, height: float = None) -> float:
         """
         Get or set the height of the object.
+
         :param height: the width to set to in pixels, if any
         :return: the height of the object
         """
@@ -2890,6 +2929,7 @@ class Oval(Renderable):
         """
         Gets the slices of the Oval based on wedges. Note that this generates slices that are not tied to the oval,
         these are simply slices of the oval based on its wedges. You can use them how you see fit.
+
         :return: a tuple (immutable list) of CustomPolygons
         """
 
@@ -3737,6 +3777,7 @@ class Image(Renderable):
     def width(self, width: float = None) -> float:
         """
         Get or set the width of the image (REQUIRES: PIL or Pillow)
+
         :param width: the width to set to, if any
         :return: None
         """
@@ -3751,6 +3792,7 @@ class Image(Renderable):
     def height(self, height: float = None) -> float:
         """
         Get or set the height of the image
+
         :param height: the height to set to, if any
         :return: the height
         """
@@ -3765,6 +3807,7 @@ class Image(Renderable):
     def color(self, color: Color = None, alpha: int = 123) -> Color:
         """
         Retrieves or applies a color-mask to the image
+
         :param color: the color to mask to, if any
         :param alpha: The alpha level of the mask, defaults to 123 (half of 255)
         :return: the mask-color of the object
@@ -3781,6 +3824,7 @@ class Image(Renderable):
     def rotation(self, angle: float = None) -> float:
         """
         Get or set the rotation of the image.
+
         :param angle: the angle to set the rotation to in degrees, if any
         :return: the angle of the image's rotation in degrees
         """
@@ -3796,6 +3840,7 @@ class Image(Renderable):
     def rotate(self, angle_diff: float) -> None:
         """
         Rotate the angle of the image by a difference, in degrees
+
         :param angle_diff: the angle difference to rotate by
         :return: None
         """
@@ -3808,6 +3853,7 @@ class Image(Renderable):
     def center(self, *args, **kwargs) -> Location:
         """
         Returns the location of the center
+
         :param move_to: if defined, Move the center to a new Location (Easily center objects!)
         :param x: if defined, move the center x-coordinate to the specified value
         :param y: if defined, move the center y-coordinate to the specified value
@@ -3862,6 +3908,7 @@ class Image(Renderable):
     def border(self, color: Color = None) -> Color:
         """
         Add or get the border of the image
+
         :param color: the color to set the border too, set to Color.NONE to remove border
         :return: The Color of the border
         """
@@ -3884,6 +3931,7 @@ class Image(Renderable):
         """
         Returns the list of vertices for the Renderable.
         (The vertices will be returned clockwise, starting from the top-leftmost point)
+
         :return: a list of Locations representing the vertices
         """
 
@@ -3922,6 +3970,7 @@ class Image(Renderable):
     def load(self) -> None:
         """
         Load animated GIF (reads frames)
+
         :return: None
         """
 
@@ -3938,6 +3987,7 @@ class Image(Renderable):
     def next(self) -> None:
         """
         Changes frame to the next frame (Can only be used with animated GIFs)
+
         :return:
         """
         self._frame += 1
@@ -3950,6 +4000,7 @@ class Image(Renderable):
     def frame(self, frame: int = None) -> int:
         """
         Set the current frame.
+
         :param frame: the frame-index to set to
         :return: the current frame
         """
@@ -3963,6 +4014,7 @@ class Image(Renderable):
     def frames(self) -> int:
         """
         Returns how many frames there are, returns -1 if not animated, 0 if corrupted file.
+
         :return:
         """
 
@@ -3977,6 +4029,7 @@ class Image(Renderable):
     def _monkey_patch_del():
         """
         We monkey patch the del function for PIL, so it doesn't do stupid things.
+
         :return:
         """
         from PIL import ImageTk
@@ -4390,6 +4443,7 @@ class Text(CustomRenderable):
     def text(self, text: str = None) -> str:
         """
         Get or set the text. Use '\n' to separate lines
+
         :param text: text to set to (str), if any
         :return: the text
         """
@@ -4409,6 +4463,7 @@ class Text(CustomRenderable):
     def move(self, *args, **kwargs) -> None:
         """
         Can take either a tuple, Location, or two numbers (dx, dy)
+
         :return: None
         """
 
@@ -4420,6 +4475,7 @@ class Text(CustomRenderable):
     def moveto(self, *args, **kwargs) -> None:
         """
         Move to a new location takes a Location, tuple, or two numbers (x, y)
+
         :return: None
         """
 
@@ -4432,6 +4488,7 @@ class Text(CustomRenderable):
     def width(self) -> float:
         """
         Get the width of the text (cannot be modified)
+
         :return the width of the text
         """
 
@@ -4441,6 +4498,7 @@ class Text(CustomRenderable):
     def height(self) -> float:
         """
         Get the height of the text, (cannot be modified, although technically the font-size is the text's height)
+
         :return: the height of the text.
         """
 
@@ -4449,6 +4507,7 @@ class Text(CustomRenderable):
     def color(self, color: Color = None) -> Color:
         """
         Get or set the color of the text
+
         :param color: the color to set to, if any
         :return: the color of the text
         """
@@ -4464,6 +4523,7 @@ class Text(CustomRenderable):
     def font(self, font: str = None) -> str:
         """
         Get or set the font of the text
+
         :param font: the font to set to, if any
         :return: the font of the text
         """
@@ -4479,6 +4539,7 @@ class Text(CustomRenderable):
     def size(self, size: int = None) -> int:
         """
         Get or set the size of the text
+
         :param size: the size to set to, if any
         :return: the size of the text
         """
@@ -4494,6 +4555,7 @@ class Text(CustomRenderable):
     def align(self, align: str = None) -> str:
         """
         Get or set the alignment of the text, if a new value is passed it must be 'left', 'center', or 'right'.
+
         :param align: the alignment to set to, if any
         :return: the alignment of the text
         """
@@ -4512,6 +4574,7 @@ class Text(CustomRenderable):
     def bold(self, bold: bool = None) -> bool:
         """
         Get or set the bold status of the text
+
         :param bold: the bold status to set to, if any
         :return: the bold status of the text
         """
@@ -4527,6 +4590,7 @@ class Text(CustomRenderable):
     def italic(self, italic: bool = None) -> bool:
         """
         Get or set the italic status of the text
+
         :param italic: the italic status to set to, if any
         :return: the italic status of the text
         """
@@ -4542,6 +4606,7 @@ class Text(CustomRenderable):
     def underline(self, underline: bool = None) -> bool:
         """
         Get or set the underline status of the text
+
         :param underline: the underline status to set to, if any
         :return: the underline status of the text
         """
@@ -4557,6 +4622,7 @@ class Text(CustomRenderable):
     def strikethrough(self, strikethrough: bool = None) -> bool:
         """
         Get or set the strikethrough status of the text
+
         :param strikethrough: the strikethrough status to set to, if any
         :return: the strikethrough status of the text
         """
@@ -4572,6 +4638,7 @@ class Text(CustomRenderable):
     def rotation(self, rotation: float = None) -> float:
         """
         Get or set the rotation of the text
+
         :param rotation: the strikethrough to set to, if any
         :return: the rotation of the text
         """
@@ -4587,6 +4654,7 @@ class Text(CustomRenderable):
     def rotate(self, angle_diff: float = 0) -> None:
         """
         Rotate the angle of the text by a difference, in degrees
+
         :param angle_diff: the angle difference to rotate by
         :return: Nonea
         """
@@ -4610,6 +4678,7 @@ class Text(CustomRenderable):
     def center(self, *args, **kwargs) -> Location:
         """
         Returns the location of the center
+
         :param move_to: if defined, Move the center to a new Location (Easily center objects!)
         :param x: if defined, move the center x-coordinate to the specified value
         :param y: if defined, move the center y-coordinate to the specified value
@@ -4663,6 +4732,7 @@ class Text(CustomRenderable):
     def vertices(self) -> list:
         """
         Get the vertices of a Rectangle superposed in the same transform of the Text
+
         :return: a list of Locations
         """
 
@@ -4694,6 +4764,7 @@ class Text(CustomRenderable):
     def visible(self, visible: bool = None) -> bool:
         """
         Get or set the visibility of the text
+
         :param visible: the visibility to set to, if any
         :return: the visibility of the text
         """
@@ -4711,6 +4782,7 @@ class Text(CustomRenderable):
     def transform(self, transform: tuple = None) -> tuple:
         """
         Retrieve the transform of the text
+
         :param transform: Unsupported.
         :return: a tuple with representing: (width, height, angle)
         """
@@ -4723,6 +4795,7 @@ class Text(CustomRenderable):
     def clone(self):
         """
         Clone this text!
+
         :return: A cloned text object!
         """
 
@@ -4917,6 +4990,7 @@ class Line(Object):
     def pos1(self, *args) -> Location:
         """
         Get or set the position of the first endpoint.
+
         :param args: Either a location or two numbers (x, y) may be passed here.
         :return: the position of the first endpoint.
         """
@@ -4939,6 +5013,7 @@ class Line(Object):
     def pos2(self, *args) -> Location:
         """
         Get or set the position of the second endpoint.
+
         :param args: Either a location or two numbers (x, y) may be passed here.
         :return: the position of the second endpoint.
         """
@@ -5016,6 +5091,7 @@ class Line(Object):
     def moveto(self, *args, **kwargs) -> None:
         """
         Move both of the endpoints to new locations.
+
         :param args: Either two locations, tuples, or four numbers (x1, y1, x2, y2).
         :return: None
         """
@@ -5063,6 +5139,7 @@ class Line(Object):
     def lookat(self, *args, **kwargs) -> None:
         """
         Make the line look at the given point by moving the second point.
+
         :return: None
         """
 
@@ -5113,6 +5190,7 @@ class Line(Object):
     def rotation(self, angle: float = None):
         """
         Get or set the rotation of the line (works via pos2()).
+
         :param angle: the angle in degrees to rotate by, if any
         :return: the angle of the line
         """
@@ -5128,6 +5206,7 @@ class Line(Object):
     def rotate(self, angle_diff: float, point: int = 1) -> float:
         """
         Rotate the line around one of its vertices (1 by default)
+
         :param angle_diff: the angle to rotate by
         :param point: the point to serve as the origin.
         :return: the new angle
@@ -5159,6 +5238,7 @@ class Line(Object):
     def location(self) -> tuple:
         """
         Returns the locations of both the endpoints
+
         :return: the locations of both the endpoints
         """
 
@@ -5167,6 +5247,7 @@ class Line(Object):
     def length(self) -> float:
         """
         Get the length of the line
+
         :return: the length of the line
         """
 
@@ -5179,6 +5260,7 @@ class Line(Object):
     def color(self, color: Color = None) -> Color:
         """
         Get or set the color of the line
+
         :param color: the color to set to, if any
         :return: the color of the line
         """
@@ -5195,6 +5277,7 @@ class Line(Object):
     def thickness(self, thickness: int = None) -> int:
         """
         Get or set the thickness of the line
+
         :param thickness: the thickness to set to, if any
         :return: the thickness of the line
         """
@@ -5235,6 +5318,7 @@ class Line(Object):
     def visible(self, visible: bool = None) -> bool:
         """
         Get or set the visibility of the line
+
         :param visible: the visibility to set to, if any
         :return: the visibility of the line
         """
@@ -5252,6 +5336,7 @@ class Line(Object):
     def transform(self, transform: tuple = None):
         """
         Copy the line's length and angle!
+
         :param transform:
         :return:
         """
@@ -5264,6 +5349,7 @@ class Line(Object):
     def clone(self):
         """
         Clone a new line!
+
         :return: A clone of this line
         """
 
@@ -5273,6 +5359,7 @@ class Line(Object):
     def intersects(self, obj) -> bool:
         """
         Check if a line intersects with another line or Renderable
+
         :param obj: Line, Renderable, or List/Tuple
         :return: Whether the line intersects with the object
         """
@@ -5296,6 +5383,7 @@ class Line(Object):
             """
             Internal method that will determine the orientation of three points. They can be a clockwise triangle,
             counterclockwise triangle, or a co-linear line segment.
+
             :param point1: the first point of the main line segment
             :param point2: the second point of the main line segment
             :param point3: the third point to check from another line segment

--- a/pydraw/overload.py
+++ b/pydraw/overload.py
@@ -77,6 +77,7 @@ def reverse_dict(d):
     >>> d = {'a': (1, 2), 'b': (2, 3), 'c':()}
     >>> reverse_dict(d)  # doctest: +SKIP
     {1: ('a',), 2: ('a', 'b'), 3: ('b',)}
+
     :note: dict order are not deterministic. As we iterate on the
         input dict, it make the output of this function depend on the
         dict order. So this function output order should be considered

--- a/pydraw/scene.py
+++ b/pydraw/scene.py
@@ -16,6 +16,7 @@ class Scene:
     def screen(self):
         """
         Retrieve the screen that the scene is tied to
+
         :return: a Screen
         """
         return self._screen
@@ -23,12 +24,14 @@ class Scene:
     def start(self) -> None:
         """
         Run as the initializer for the scene
+
         :return: None
         """
 
     def run(self) -> None:
         """
         Run the scene (the loop should go here)
+
         :return: None
         """
 
@@ -78,6 +81,7 @@ class Scene:
     def keyup(self, key: Screen.Key) -> None:
         """
         Key event called when a key is released
+
         :param key: the Key that was released
         :return: None
         """
@@ -85,6 +89,7 @@ class Scene:
     def activate(self, screen: Screen) -> None:
         """
         Activates the Scene with a Screen (called internally)
+
         :param screen: the Screen to display the Scene on
         :return: None
         """

--- a/pydraw/screen.py
+++ b/pydraw/screen.py
@@ -191,6 +191,7 @@ class Screen:
     def title(self, title: str = None) -> str:
         """
         Get or set the title of the screen.
+
         :param title: the title to set to, if any
         :return: the title
         """
@@ -205,6 +206,7 @@ class Screen:
     def color(self, color: Color = None) -> Color:
         """
         Set the background color of the screen.
+
         :param color: the color to set the background to
         :return: None
         """
@@ -218,6 +220,7 @@ class Screen:
     def picture(self, pic: str) -> None:
         """
         Set the background picture of the screen.
+
         :param pic: the path to said picture from the file
         :return: None
         """
@@ -230,6 +233,7 @@ class Screen:
         @deprecated (does not work on all OSes)
 
         Resize the screen to new dimensions
+
         :param width: the width to resize to
         :param height: the height to resize to
         :return: None
@@ -251,6 +255,7 @@ class Screen:
         """
         Get the size of the WINDOW (please note this is not the canvas, and those attributes should be
         retrieved using the width() and height() methods respectively)
+
         :return: a tuple containing the width and height of the WINDOW
         """
 
@@ -263,6 +268,7 @@ class Screen:
     def width(self) -> int:
         """
         Returns the width of the CANVAS within the screen. Important.
+
         :return: an integer representing the width of the canvas
         """
 
@@ -275,6 +281,7 @@ class Screen:
     def height(self) -> int:
         """
         Returns the height of the CANVAS within the screen. Important.
+
         :return:
         """
 
@@ -295,6 +302,7 @@ class Screen:
     def top_left(self) -> Location:
         """
         Returns the top left corner of the screen
+
         :return: Location
         """
 
@@ -303,6 +311,7 @@ class Screen:
     def top_right(self) -> Location:
         """
         Returns the top right corner of the screen
+
         :return: Location
         """
 
@@ -311,6 +320,7 @@ class Screen:
     def bottom_left(self) -> Location:
         """
         Returns the bottom left corner of the screen
+
         :return: Location
         """
 
@@ -319,6 +329,7 @@ class Screen:
     def bottom_right(self) -> Location:
         """
         Returns the bottom right corner of the screen
+
         :return: Location
         """
 
@@ -327,6 +338,7 @@ class Screen:
     def mouse(self) -> Location:
         """
         Get the current mouse-position
+
         :return: the mouse-position in the form of a Location
         """
 
@@ -336,6 +348,7 @@ class Screen:
     def alert(self, text: str, title: str = 'Alert', accept_text: str = 'Ok', cancel_text: str = 'Cancel') -> bool:
         """
         Displays a dialog-box alert, and returns
+
         :param text: The text to display in the body of the dialog
         :param title: The title of the dialog-box
         :param accept_text: The text displayed on the accept button, defaults to 'Ok'
@@ -357,6 +370,7 @@ class Screen:
     def prompt(self, text: str, title: str = 'Prompt') -> str:
         """
         Prompts the user for keyboard input
+
         :param: text the text to prompt the user with
         :param: title the title of the dialog box
         :return: None
@@ -427,6 +441,7 @@ class Screen:
     def gridlines(self) -> tuple:
         """
         Allows you to retrieve the lines of the grid, but note that you cannot modify them!
+
         :return: a tuple (immutable list) of the gridlines.
         """
 
@@ -462,6 +477,7 @@ class Screen:
         """
         Grabs a screenshot of the image and saves it to the directory with the specified filename!
         Note that if no filename is specified the file will be given a name based on the epoch time.
+
         :param filename: the name of the file to save the screenshot to.
         :return: the name of the file.
         """
@@ -496,6 +512,7 @@ class Screen:
         will it REPOSITION them. It is highly recommended that you call this method before creating any shapes!
 
         !!! EXPERIMENTAL !!!
+
         :param fullscreen: the new fullscreen state, if any
         :return: the current fullscreen state of the Screen
         """
@@ -527,6 +544,7 @@ class Screen:
     def _add(self, obj) -> None:
         """
         Internal method which adds object to a list upon construction.
+
         :param obj: the object to add.
         :return: None
         """
@@ -536,6 +554,7 @@ class Screen:
     def add(self, obj) -> None:
         """
         Add an object back to the Screen after having removed it (with Object.remove() or Screen.remove(object)
+
         :param obj: the Object to add back.
         :return: None
         """
@@ -561,6 +580,7 @@ class Screen:
     def objects(self) -> tuple:
         """
         Retrieves all objects on the Screen!
+
         :return: A tuple (immutable list) of Objects (you will want to check types for certain methods!)
         """
 
@@ -569,6 +589,7 @@ class Screen:
     def contains(self, obj) -> bool:
         """
         Returns whether or not the passed object exists on the Screen (is in the objects cache)
+
         :param obj: the Object to check
         :return: a boolean
         """
@@ -581,6 +602,7 @@ class Screen:
     def clear(self) -> None:
         """
         Clears the screen.
+
         :return: None
         """
 
@@ -598,6 +620,7 @@ class Screen:
         Apply a new scene to the screen!
 
         Note that this will override ALL previously registered input handlers.
+
         :param scene: The Scene to apply!
         :return: None
         """
@@ -627,6 +650,7 @@ class Screen:
     def reset(self) -> None:
         """
         Resets the screen, removing all objects and input methods.
+
         :return: None
         """
 
@@ -676,6 +700,7 @@ class Screen:
     def update(self) -> None:
         """
         Updates the screen.
+
         :return: None
         """
         try:
@@ -690,6 +715,7 @@ class Screen:
     def stop(self) -> None:
         """
         Deprecated. Use `screen.loop` instead.
+
         :return: None
         """
 
@@ -711,6 +737,7 @@ class Screen:
         """
         Called at the end of pydraw programs as an event for succesful program execution and termination.
         For something similar to turtle.done() see Screen.stop()
+
         :return: None
         """
 
@@ -722,6 +749,7 @@ class Screen:
         """
         Takes a pydraw Color and returns a tkinter-friendly string, while also preventing errors
         from occurring after tkinter has shut down.
+
         :param color: the Color to convert
         :return: the converted color (tkinter-str)
         """
@@ -748,6 +776,7 @@ class Screen:
           - keydown
           - keyup
           - keypress (deprecated)
+
         :return: None
         """
 
@@ -793,6 +822,7 @@ class Screen:
         def key(self) -> str:
             """
             Returns the string for the key.
+
             :return: the key in ascii
             """
             return self._key
@@ -812,6 +842,7 @@ class Screen:
         def __eq__(self, obj) -> bool:
             """
             Overrides the equals operator so that we can compare with strings! Fantastic!
+
             :param obj: the object to compare to
             :return: if the key is equal to the object.
             """
@@ -825,6 +856,7 @@ class Screen:
     def _create_lambda(self, method: str, key):
         """
         A super-cool method to create lambdas for key-event registration.
+
         :param key: the key to create the lambda for
         :return: A lambda (😻) [ignore the cat]
         """
@@ -966,6 +998,7 @@ class Screen:
     def create_location(self, x, y, canvas: bool = False) -> Location:
         """
         Is passed turtle-based coordinates and converts them into normal coordinates
+
         :param x: the x component
         :param y: the y component
         :param canvas: whether or not the supplied coordinates are from the canvas or input
@@ -985,6 +1018,7 @@ class Screen:
     def _onrelease(self, fun, btn, add=None):
         """
         An internal method hooking into the TKinter canvas.
+
         :param fun: the function to call upon mouse release
         :param btn: the mouse button to bind to
         :param add: i have no clue what this does
@@ -1001,6 +1035,7 @@ class Screen:
     def _ondrag(self, fun, btn, add=None):
         """
         An internal method hooking into the TKinter canvas.
+
         :param fun: the function to call upon drag
         :param btn: the mouse button to bind to
         :param add: i have no clue

--- a/pydraw/util.py
+++ b/pydraw/util.py
@@ -4,6 +4,7 @@ from pydraw.errors import *
 def verify_type(obj, required_type):
     """
     Verifies an objects type is the passed type
+
     :param obj: the object to check
     :param required_type: the expected type
     :return: True if required type is present or obj is None, else False
@@ -23,6 +24,7 @@ def verify_type(obj, required_type):
 def verify(*args):
     """
     Takes a list of values and expected types and returns if all objects meet their expected types.
+
     :param args: a list of objects and types, ex: (some_number, float, some_location, Location)
     :return: True if all args meet their expected types, throws an error if not.
     """


### PR DESCRIPTION
## Problem

Sphinx (autodoc) only parses a `:param:`/`:return:` field list when a **blank line** separates it from the preceding summary text. Almost every docstring in the package was missing that blank line, so on the rendered API pages the fields showed up as inline prose, e.g.:

> Mouse event, called when a mouse button is pressed down. :param button: the button pressed (0-2) :param location: the location that was clicked :return: None

instead of a proper parameters table.

## Fix

Insert the missing blank line before the first field-list line of each affected docstring — **164 spots** across 8 modules. Purely additive (no lines changed or removed); all modules still compile; no line-ending changes.

| file | added |
|---|---|
| objects.py | 88 |
| screen.py | 35 |
| compound.py | 18 |
| color.py | 11 |
| scene.py | 5 |
| location.py | 4 |
| util.py | 2 |
| overload.py | 1 |
